### PR TITLE
Update github templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Set the tech writing team as owners for the docs
+/pages/ @ethyca/docs-authors

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Set the tech writing team as owners for the docs
-/pages/ @ethyca/docs-authors

--- a/.github/ISSUE_TEMPLATE/ethyca_docs_update.md
+++ b/.github/ISSUE_TEMPLATE/ethyca_docs_update.md
@@ -12,7 +12,7 @@ Describe the problem: _What isn't working?_
 
 Describe the purpose: _What needs to happen?_
 
-Describe the related work: _Brief summary of what was updated, so documentation can be written._
+Describe the related work: _Brief summary of any related engineering tickets, features, etc._
 
 Related links: _Engineering tickets, PRs, Figma specs, current docs pages, etc._
 

--- a/.github/ISSUE_TEMPLATE/ethyca_docs_update.md
+++ b/.github/ISSUE_TEMPLATE/ethyca_docs_update.md
@@ -1,0 +1,21 @@
+---
+name: Docs Update
+about: Change suggestions for the Fides documentation
+title: ''
+labels: documentation
+
+---
+
+### Docs Update Description
+
+Describe the problem: _What isn't working?_
+
+Describe the purpose: _What needs to happen?_
+
+Describe the related work: _Brief summary of what was updated, so documentation can be written._
+
+Related links: _Engineering tickets, PRs, Figma specs, current docs pages, etc._
+
+### Additional context
+
+_Add any other context about the problem here._

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+Closes <issue>
+
+### Description of Changes
+
+* [ ] _list your docs changes here; if possible, link to the vercel preview of your updated page_
+
+### Pre-Merge Checklist
+
+* [ ] All CI Pipelines Succeeded
+* [ ] Issue Requirements are Met
+* [ ] Relevant Follow-Up Issues Created


### PR DESCRIPTION
Goals:
* Override the Ethyca issue templates to be more specific for documentation needs in this repository
* Add a minimum PR checklist that can be added to

I ended up removing the docs team as a repo codeowner, as with myself as the main contributor and no other codeowners, it would create the same issues we've seen in the fideslang repo.