### PR TITLE
Fix Fides Join-Slack URL

### DIFF
--- a/pages/fides/community/overview.md
+++ b/pages/fides/community/overview.md
@@ -4,6 +4,6 @@ We believe the only way to solve privacy is as a community of likeminded develop
 
 [Start Contributing](https://github.com/ethyca/fides)
 
-[Chat on Slack](https://www.fid.es/join-slack)
+[Chat on Slack](https://fid.es/join-slack)
 
 [Chat on Discord](https://discord.gg/6bKp5qVnSR)

--- a/theme.config.js
+++ b/theme.config.js
@@ -152,7 +152,7 @@ export default {
           <div className="socials">
             <div className="icons"> 
 
-                <a href="https://www.fid.es/join-slack" rel="noopener"> <img src ="/assets/slack.svg" /> </a>
+                <a href="https://fid.es/join-slack" rel="noopener"> <img src ="/assets/slack.svg" /> </a>
                 <a href="https://www.linkedin.com/company/ethyca/" rel="noopener"> <img src ="/assets/linkedin.svg" /> </a>
                 <a href="https://twitter.com/ethyca" rel="noopener">  <img src ="/assets/twitter.svg" /> </a>
                 <a href="https://github.com/ethyca/fides" rel="noopener">  <img src ="/assets/github.svg" /> </a>


### PR DESCRIPTION
### Description of Changes

* Remove `www` from the link-shortened fid.es/join-slack URL

### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
