### PR TITLE
Resolve remaining 404 links on site

### DIFF
--- a/pages/docs/configuration/oauth/_meta.json
+++ b/pages/docs/configuration/oauth/_meta.json
@@ -1,7 +1,7 @@
 {
-    "overview": "Overview",
+    "index": "Overview",
     "generating-tokens": "Generating OAuth Access Tokens",
+    "api-authentication": "API Authentication",
     "token-expiration": "OAuth Token Expiration",
-    "calling-api": "Calling the API",
     "creating-clients": "Creating OAuth Clients"
 }

--- a/pages/docs/configuration/oauth/api-authentication.mdx
+++ b/pages/docs/configuration/oauth/api-authentication.mdx
@@ -1,6 +1,6 @@
 import { Callout } from 'nextra-theme-docs'
 
-# Calling the API
+# API Authentication with OAuth
 
 The Fides API requires authentication via OAuth using a valid access token. In this document we'll walk through calling the Fides API with a valid access token and the appropriate scopes.
  

--- a/pages/docs/configuration/oauth/generating-tokens.mdx
+++ b/pages/docs/configuration/oauth/generating-tokens.mdx
@@ -34,4 +34,4 @@ Content-Type: application/json
 }
 ```
 
-From here you can [authenticate to the API with this access token](authentication) and the appropriate scopes.
+From here you can [authenticate to the API with this access token](calling-api) and the appropriate scopes.

--- a/pages/docs/configuration/oauth/index.mdx
+++ b/pages/docs/configuration/oauth/index.mdx
@@ -8,7 +8,8 @@ If you're looking for information on configuring a root OAuth client, read the [
 For details, see:
 
 * [Generating OAuth Access Tokens](generating-tokens)
-* [Token Expiration](token-expiration)
-* [Authenticating via OAuth](authentication)
+* [API Authentication](api-authentication)
+* [OAuth Token Expiration](token-expiration)
 * [Creating OAuth Clients](creating-clients)
+
 

--- a/pages/docs/configuration/oauth/token-expiration.mdx
+++ b/pages/docs/configuration/oauth/token-expiration.mdx
@@ -2,6 +2,6 @@ import { Callout } from 'nextra-theme-docs'
 
 # Access token expiration
 
-By default, access tokens expire after 11520 minutes (8 days). If you call the Fides API with an expired token, Fides will response with a `401` unauthorized response.
+By default, access tokens expire after 11520 minutes (8 days). If you call the Fides API with an expired token, Fides will respond with a `401` unauthorized response.
 
 To specify a different expiration time (in minutes) set the `OAUTH_ACCESS_TOKEN_EXPIRE_MINUTES` environment variable, or the `oauth_access_token_expire_minutes` value in your `fides.toml`. Read the [Configuration Guide](#LINK) to learn more.

--- a/pages/docs/get-started/advanced.mdx
+++ b/pages/docs/get-started/advanced.mdx
@@ -125,7 +125,7 @@ FIDES__ADMIN_UI__ENABLED=true
 | `FIDES__REDIS__PASSWORD` | The password created for Fides to access the Redis cache.
 
 
-See the [Configuration guide](configuration) for a full list of settings, as well as a sample `fides.toml`.
+See the [Configuration guide](/docs/configuration/configuration) for a full list of settings, as well as a sample `fides.toml`.
 
 ## Running the webserver
 Once configured, you can start your server:

--- a/pages/docs/get-started/sample-project.mdx
+++ b/pages/docs/get-started/sample-project.mdx
@@ -37,7 +37,7 @@ If your browser does not open automatically, you should navigate to `http://loca
 The project contains:
 
 * The Fides Control admin UI for managing [privacy requests](/tutorials/privacy-requests-get-started)
-* The Fides [Privacy Center](/guide/privacy-center) for submitting requests
+* The Fides [Privacy Center](/guides/privacy-center) for submitting requests
 * The sample Cookie House eCommerce site for testing
 * A DSR Directory on your computer to view results
 

--- a/pages/docs/privacy-requests/overview.mdx
+++ b/pages/docs/privacy-requests/overview.mdx
@@ -89,7 +89,7 @@ GET /api/v1/privacy-request?request_id=<privacy_request_id>
 GET /api/v1/privacy-request?external_id=<external_id>
 ```
 
-For more detailed examples and further privacy request filtering, see [Reporting on Privacy Requests](./reporting).
+For more detailed examples and further privacy request filtering, see [Reporting on Privacy Requests](/docs/configuration/reporting).
 
 ### Restart failed requests
 To restart a failed privacy request, call the following endpoint with an empty request body:
@@ -158,4 +158,4 @@ a similar process for each CSV file.
 
 ## Privacy request integrations
 
-* **Generic API interoperability**: Third party services can be authorized by creating additional OAuth clients. Tokens obtained from OAuth clients can be managed and revoked at any time. See [authenticating with OAuth](/docs/configuration/oauth/overview) for more information.
+* **Generic API interoperability**: Third party services can be authorized by creating additional OAuth clients. Tokens obtained from OAuth clients can be managed and revoked at any time. See [authenticating with OAuth](/docs/configuration/oauth) for more information.

--- a/pages/docs/privacy-requests/privacy-request-data-rights-protocol.mdx
+++ b/pages/docs/privacy-requests/privacy-request-data-rights-protocol.mdx
@@ -6,7 +6,7 @@ As a Privacy Infrastructure Provider (PIP), Fides conforms to the DRP standards 
 
 ## DRP Actions
 
-A [DRP action](https://github.com/consumer-reports-digital-lab/data-rights-protocol#301-supported-rights-actions) may be defined when creating or editing a [policy](docs/privacy-requests/privacy-request-graphs). These actions associate a Fides privacy request policy with a DRP-standardized protocol for receiving and processing Data Rights Requests.
+A [DRP action](https://github.com/consumer-reports-digital-lab/data-rights-protocol#301-supported-rights-actions) may be defined when creating or editing a [policy](/docs/privacy-requests/privacy-request-graphs). These actions associate a Fides privacy request policy with a DRP-standardized protocol for receiving and processing Data Rights Requests.
 
 A given action may only be associated to a single policy:
 

--- a/pages/docs/privacy-requests/privacy-request-execution.mdx
+++ b/pages/docs/privacy-requests/privacy-request-execution.mdx
@@ -98,7 +98,7 @@ If masking fails on a given Collection, Fides retries the requests for a configu
 
 
 ### Send erasure request emails
-After the access and erasure steps have both executed, Fides checks if there are any third parties that need to be additionally emailed to complete erasure requests on your behalf. See [emailing third party services to mask data](messaging#Email-third-party-services-to-mask-data) for more information.
+After the access and erasure steps have both executed, Fides checks if there are any third parties that need to be additionally emailed to complete erasure requests on your behalf.
 
 Fides retrieves any masking instructions cached by Email Connectors in the erasure request step, and combines them into a single email per Dataset.
 

--- a/pages/tutorials/consent-management-configuration/privacy-experiences/overlay.mdx
+++ b/pages/tutorials/consent-management-configuration/privacy-experiences/overlay.mdx
@@ -16,7 +16,7 @@ For this tutorial you'll need:
 
 * A Fides Cloud or Fides Enterprise account
 * The role of `Owner` or `Contributor` for your Fides organization.
-* At least one system with a data use on your Data Map. Read how to [add systems to the Data Map](..//tutorials/data-mapping-adding-systems-manually) now.
+* At least one system with a data use on your Data Map. Read how to [add systems to the Data Map](/tutorials/data-mapping-adding-systems-manually) now.
 * At least one privacy notice configured. Read how to [configure privacy notices](../privacy-notices) now.
 
 

--- a/pages/tutorials/consent-management-configuration/privacy-experiences/privacy-center.mdx
+++ b/pages/tutorials/consent-management-configuration/privacy-experiences/privacy-center.mdx
@@ -16,7 +16,7 @@ For this tutorial you'll need:
 
 * A Fides Cloud or Fides Enterprise account
 * The role of `Owner` or `Contributor` for your Fides organization.
-* At least one system with a data use on your Data Map. Read how to [add systems to the Data Map](..//tutorials/data-mapping-adding-systems-manually) now.
+* At least one system with a data use on your Data Map. Read how to [add systems to the Data Map](/tutorials/data-mapping-adding-systems-manually) now.
 * At least one privacy notice configured. Read how to [configure privacy notices](../privacy-notices) now.
 
 

--- a/pages/tutorials/consent-management-configuration/privacy-notices.mdx
+++ b/pages/tutorials/consent-management-configuration/privacy-notices.mdx
@@ -8,7 +8,7 @@ import Screenshot from 'components/screenshot'
 
 In this tutorial, we'll review privacy notices and how they're created, updated, and served to visitors based on location.
 
-After reading this, you'll be familiar with how data uses from the [previous section](consent-management-configuring-data-use-for-consent) automatically generate privacy notices, as well as how to create and manage your own custom privacy notices.
+After reading this, you'll be familiar with how data uses from the [previous section](/tutorials/consent-management-configuration/data-use-for-consent) automatically generate privacy notices, as well as how to create and manage your own custom privacy notices.
 
 ## Prerequisites
 

--- a/pages/tutorials/privacy-requests-configuration/databases.mdx
+++ b/pages/tutorials/privacy-requests-configuration/databases.mdx
@@ -29,7 +29,7 @@ In Fides, a database schema is referred to as a dataset. Read about [creating an
 
 To start, navigate to **Data map** → **View systems** to view a list of your current systems. 
 
-If you have not already added your database to Fides, read how to [add systems to the Data Map](data-mapping-adding-systems-manually) now.
+If you have not already added your database to Fides, read how to [add systems to the Data Map](/tutorials/data-mapping-adding-systems-manually) now.
 
 ### Select a System to Edit
 

--- a/pages/tutorials/privacy-requests-debugging.mdx
+++ b/pages/tutorials/privacy-requests-debugging.mdx
@@ -15,7 +15,7 @@ For this tutorial, you'll need:
 
 * A Fides Cloud or Fides Enterprise account
 * The role of either `Owner`, `View & Approver` or `Approver` to manage privacy requests.
-* At least one system integration configured for privacy requests. Read how to [configure an integration](integrations).
+* At least one system integration configured for privacy requests. Read how to [configure an integration](/tutorials/privacy-requests-configuration/integrations).
 * A privacy center to receive and process privacy requests. Read how to [configure a privacy center](#LINK).
 
 

--- a/pages/tutorials/privacy-requests-workflow.mdx
+++ b/pages/tutorials/privacy-requests-workflow.mdx
@@ -15,7 +15,7 @@ For this tutorial, you'll need:
 
 * A Fides Cloud or Fides Enterprise account
 * The role of either `Owner`, `View & Approver` or `Approver` to manage privacy requests.
-* At least one system integration configured for privacy requests. Read how to [configure an integration](integrations).
+* At least one system integration configured for privacy requests. Read how to [configure an integration](/tutorials/privacy-requests-configuration/integrations).
 * A privacy center to receive and process privacy requests. Read how to [configure a privacy center](#LINK).
 
 


### PR DESCRIPTION
Closes the remaining 404 links from the Site Checker SEO report

### Description of Changes
* Updated ~25 remaining 404 links to close out the remaining 404 errors.