### PR TITLE
edit /docs and /tutorials to fix feature module links

### DIFF
--- a/pages/docs.mdx
+++ b/pages/docs.mdx
@@ -6,22 +6,12 @@ import KeyFeatWrap, { KeyFeat } from 'components/keyfeat'
 Fides is a Privacy-as-Code tool that lets you easily integrate and automate privacy into every stage of your tech stack and software development. This includes data mapping and inventory, privacy request (DSR) automation, consent management and enforcement as well as automated privacy checks.
 
 ## Introduction
-<KeyFeatWrap>
-  <KeyFeat title="What is Fides?" link="./fides/intro"  description="Learn how Fides solves major privacy challenges."/>
-  <KeyFeat title="Use Cases" link="./fides/use-cases"  description="Popular use cases and related documentation you can use to create Fides configurations and workflows."/>
-  <KeyFeat title="Fides vs. Alternatives" link="./fides/intro/vs"   description="Learn how Fides compares to other tools and services."/>
-  <KeyFeat title="Regulations" link="../regulations"   description="Get practical step-by-step guides on major privacy regulations."/>
-</KeyFeatWrap>
 
-## Enterprise Tools
 <KeyFeatWrap>
-  <KeyFeat title="Fides Enterprise" link="/docs/enterprise/overview"  description="Fides Enterprise is a self-hosted instance of Fides build for organizations that have strict security and compliance needs."/>
-</KeyFeatWrap>
-
-## Develop and Share
-<KeyFeatWrap>
-  <KeyFeat title="Connector Development" link="#LINK"  description="Create a privacy connector to allow Fides to interact with your service."/>
-  <KeyFeat title="Registry Publishing" link="#LINK"  description="Publish a privacy connector to the Fides Registry to make it publicly available."/>
+  <KeyFeat title="Get Started" link="/docs/get-started/quickstart"  description="Learn how to get started with Fides and begin solving major privacy challenges."/>
+  <KeyFeat title="Privacy Requests" link="/docs/privacy-requests/overview"  description="Learn how to fulfill privacy requests with Fides."/>
+  <KeyFeat title="Connectors" link="/docs/connectors/saas-connectors"   description="Learn how to connect Fides to a third party application."/>
+  <KeyFeat title="Fides CLI" link="/docs/cli"   description="Learn Fides' CLI-based workflows to interact with the Fides Server."/>
 </KeyFeatWrap>
 
 

--- a/pages/tutorials.mdx
+++ b/pages/tutorials.mdx
@@ -10,12 +10,11 @@ import HeroCTAVisual from 'components/heroctavisual'
 Try the newest tutorials for common Fides tasks and use cases for privacy compliance and automation. Start here to learn the basics of Fides with your preferred cloud and configurations. 
 
 <KeyFeatWrap>
-
   <KeyFeat title="Privacy Request Automation" link="/tutorials/privacy-requests-get-started"  description="Go from 'Zero to DSR Automation' in your own infrastructure."/>
   <KeyFeat title="Data Mapping" link="/tutorials/data-mapping-get-started"  description="Generate maps of your systems and infrastructure with Fides' automated tools."/>
   <KeyFeat title="Managing Consent" link="/tutorials/consent-management-get-started"   description="Understand how Fides can help provide you with compliance-minded consent solutions."/>
-  <KeyFeat title="Fides for Businesses" link="/docs/enterprise/overview"   description="Use Fides for Enterprise-level data classifications, visualizations, and more."/>
 </KeyFeatWrap>
+
 
 ## Why is it called Fides?
 


### PR DESCRIPTION
Closes #127 

### Description of Changes

* Removing enterprise and developer module from /docs
* Rewriting /docs feature module to make sense 
* Editing feature module on /tutorials to ensure working links


### Pre-Merge Checklist

* [ ] All CI Pipelines Succeeded
* [ ] Issue Requirements are Met
* [ ] Relevant Follow-Up Issues Created
