### PR TITLE
Minor typo in get started guide

### DIFF
--- a/pages/dev-docs/get-started/index.mdx
+++ b/pages/dev-docs/get-started/index.mdx
@@ -6,7 +6,7 @@ import { Callout } from 'nextra-theme-docs'
 
 To get started quickly with Fides, a sample project is bundled within the Fides that will set up the Fides Server, Privacy Center, and a sample application for you to experiment with.
 
-To deploy and configure Fides in your own infrastructure, see the [Pdetailed installation](/dev-docs/get-started/advanced) and use the available [Helm chart](/dev-docs/get-started/advanced#using-helm-recommended-if-using-kubernetes) or [Terraform modules](/dev-docs/get-started/advanced#using-terraform) here.
+To deploy and configure Fides in your own infrastructure, see the [detailed installation](/dev-docs/get-started/advanced) and use the available [Helm chart](/dev-docs/get-started/advanced#using-helm-recommended-if-using-kubernetes) or [Terraform modules](/dev-docs/get-started/advanced#using-terraform) here.
 
 ## Prerequisites
 


### PR DESCRIPTION
Fixes a typo in dev-docs/get-started 
